### PR TITLE
fix: Consider user namespace first, then standard namespaces

### DIFF
--- a/pkg/bootjobs/bootjobs.go
+++ b/pkg/bootjobs/bootjobs.go
@@ -46,10 +46,7 @@ func GetSortedJobs(client kubernetes.Interface, ns string, selector string, comm
 
 // FindGitOperatorNamespace finds the git operator namespace
 func FindGitOperatorNamespace(client kubernetes.Interface, namespace string) (string, error) {
-	namespaces := []string{"jx", "jx-git-operator"}
-	if stringhelpers.StringArrayIndex(namespaces, namespace) < 0 {
-		namespaces = append(namespaces, namespace)
-	}
+	namespaces := selectOperatorNamespace(namespace)
 	name := "jx-git-operator"
 	for _, ns := range namespaces {
 		_, err := client.AppsV1().Deployments(ns).Get(context.TODO(), name, metav1.GetOptions{})
@@ -61,4 +58,12 @@ func FindGitOperatorNamespace(client kubernetes.Interface, namespace string) (st
 		}
 	}
 	return namespace, errors.Errorf("failed to find Deployment %s in namespaces %s", name, strings.Join(namespaces, ", "))
+}
+
+func selectOperatorNamespace(namespace string) []string {
+	namespaces := []string{"jx", "jx-git-operator"}
+	if stringhelpers.StringArrayIndex(namespaces, namespace) < 0 && len(namespace) > 0 {
+		namespaces = append([]string{namespace}, namespaces...)
+	}
+	return namespaces
 }

--- a/pkg/bootjobs/bootjobs_test.go
+++ b/pkg/bootjobs/bootjobs_test.go
@@ -1,0 +1,14 @@
+package bootjobs
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSelectOperatorNamespace_UsesUserProvidedNamespaceFirst(t *testing.T) {
+	assert.Equal(t, []string{"my-custom-namespace", "jx", "jx-git-operator"}, selectOperatorNamespace("my-custom-namespace"))
+}
+
+func TestSelectOperatorNamespace_DoesNotAppendEmptyNamespace(t *testing.T) {
+	assert.Equal(t, []string{"jx", "jx-git-operator"}, selectOperatorNamespace(""))
+}


### PR DESCRIPTION
Hi. Trying to install multiple instances of Jenkins X. At this moment without luck. Just fixed a tiny issue.

**EXAMPLE CASE SCENARIO:**
    - Installed JX v3 in a standard way (with jx-git-operator in standard namespace)
    - Want's to try to install a second jx-git-operator together with second JX v3
    - PREVIOUSLY: It will find an "old" operator in standard namespace

What do you think? Is this OK with conception? Could operator be installed in a separate namespace at all?