### PR TITLE
fix: update go version in makefile for m1 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ORG := jenkins-x-plugins
 ORG_REPO := $(ORG)/$(NAME)
 RELEASE_ORG_REPO := $(ORG_REPO)
 ROOT_PACKAGE := github.com/$(ORG_REPO)
-GO_VERSION := 1.13
+GO_VERSION := $(shell $(GO) version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/')
 GO_DEPENDENCIES := $(call rwildcard,pkg/,*.go) $(call rwildcard,cmd/,*.go)
 
 BRANCH     := $(shell git rev-parse --abbrev-ref HEAD 2> /dev/null  || echo 'unknown')


### PR DESCRIPTION
I suspect it's because of the hard-coded go version within the make file that the darwin arm is not built by the go releaser.
"GO_VERSION := $(shell $(GO) version | sed -e 's/^[^0-9.]([0-9.]).*/\1/')"
is from jenkins x cli makefile, where it seems to work.
https://github.com/jenkins-x/jx/blob/main/Makefile

Go Version and darwin arm support.
goreleaser/goreleaser#1952