### PR TITLE
fix: testing if GITHUB_TOKEN works for ghcr

### DIFF
--- a/.github/workflows/jenkins-x-release.yaml
+++ b/.github/workflows/jenkins-x-release.yaml
@@ -52,7 +52,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
-        password: ${{ secrets.GHCR_TOKEN }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push
       uses: docker/build-push-action@v2
       with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,9 +34,10 @@ builds:
     # Defaults are 386 and amd64.
     goarch:
       - amd64
-      - arm
       - arm64
-
+    ignore:
+      - goos: windows
+        goarch: arm64
 archives:
   - name_template: "jx-admin-{{ .Os }}-{{ .Arch }}"
     format_overrides:


### PR DESCRIPTION
also skipping build unused binaries

related to jenkins-x/jx#8670